### PR TITLE
move mention of __return__ from the docstring to the documentation

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -545,6 +545,9 @@ can be overridden by the local file.
 
    Print the return value for the last return of a function.
 
+   The return value is stored in the calling frame's locals under
+   the name ``__return__``, and it can also be fetch from there.
+
 .. rubric:: Footnotes
 
 .. [1] Whether a frame is considered to originate in a certain module

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1238,8 +1238,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def do_retval(self, arg):
         """retval
         Print the return value for the last return of a function.
-        Alternatively, the return value can be accessed with the local
-        variable ``__return__``
         """
         if '__return__' in self.curframe_locals:
             self.message(repr(self.curframe_locals['__return__']))


### PR DESCRIPTION
!!! If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

PLEASE: Remove this headline!!!
